### PR TITLE
On item click error for tabs fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lanaco/lnc-react-ui",
   "type": "module",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "description": "component library",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",

--- a/src/Layout/Tabs/TabItem.js
+++ b/src/Layout/Tabs/TabItem.js
@@ -181,7 +181,7 @@ const TabItem = React.forwardRef((props, ref) => {
     onBlur,
     onClick,
     onKeyDown,
-    onItemClick,
+    itemClick,
     //----------------
     className,
     style,
@@ -196,8 +196,8 @@ const TabItem = React.forwardRef((props, ref) => {
   const themeProps = { theme, color, size, style, className };
 
   const handleClick = (e) => {
-    if (onItemClick && !disabled) onItemClick(index);
-    if (onClick) onClick(e);
+    if (itemClick && !disabled) itemClick(index);
+    if (onClick && !disabled) onClick(e);
   };
 
   useUpdateEffect(() => {

--- a/src/Layout/Tabs/index.js
+++ b/src/Layout/Tabs/index.js
@@ -6,8 +6,8 @@ import { useTheme } from "@emotion/react";
 const TabsStyled = styled.div`
   background: transparent;
   display: flex;
-  justify-content: ${props => props.fullWidth ? 'space-evenly' : 'none'};
-  gap: ${props => props.type == "pill" ? '10px' : '0'};
+  justify-content: ${(props) => (props.fullWidth ? "space-evenly" : "none")};
+  gap: ${(props) => (props.type == "pill" ? "10px" : "0")};
   box-sizing: border-box;
 `;
 
@@ -31,12 +31,25 @@ const Tabs = React.forwardRef((props, ref) => {
 
   const themeProps = { theme, color, size, style, className };
 
-  const onItemClick = (index) => {
-     setActiveIndex(index);
-  }
+  const handleItemClick = (index) => {
+    setActiveIndex(index);
+  };
 
-  const childrenWithAdjustedProps = React.Children.map(children, (child, index) =>
-    React.cloneElement(child, { type: type, first: index == 0, last: index == React.Children.toArray(children).length - 1, fullWidth: fullWidth, index: index, onItemClick: onItemClick, activeIndex: activeIndex, color: color, size: size, fullWidth: fullWidth })
+  const childrenWithAdjustedProps = React.Children.map(
+    children,
+    (child, index) =>
+      React.cloneElement(child, {
+        type: type,
+        first: index == 0,
+        last: index == React.Children.toArray(children).length - 1,
+        fullWidth: fullWidth,
+        index: index,
+        itemClick: handleItemClick,
+        activeIndex: activeIndex,
+        color: color,
+        size: size,
+        fullWidth: fullWidth,
+      })
   );
 
   return (
@@ -76,7 +89,7 @@ Tabs.propTypes = {
     "danger",
     "information",
     "neutral",
-    "gray"
+    "gray",
   ]),
   size: PropTypes.oneOf(["small", "medium", "large"]),
 };


### PR DESCRIPTION
Renamed onItemClick, when prop name is starting with on React tries to bind it to javascript events.