### PR TITLE
#1327 - Preventing scroll in certain cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@storybook/react": "^6.5.9",
     "@storybook/theming": "^6.5.9",
     "babel-loader": "^8.2.2",
+    "cross-env": "^7.0.3",
     "css-loader": "^5.2.6",
     "eslint-plugin-react": "^7.24.0",
     "jest": "^27.5.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lanaco/lnc-react-ui",
   "type": "module",
-  "version": "3.11.3",
+  "version": "3.11.4",
   "description": "component library",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",

--- a/src/Utility/TreeMenu/MenuItem.js
+++ b/src/Utility/TreeMenu/MenuItem.js
@@ -157,7 +157,8 @@ const MenuItem = React.forwardRef((props, ref) => {
     onBlur(e);
   };
   const handleOnKeyDown = (e) => {
-    e.preventDefault(); //prevents scroll
+    if (['Space', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].indexOf(e.code) > -1)
+      e.preventDefault(); // prevents scroll
 
     if (e.key == "ArrowDown") {
       focusNextItem(ref ? ref.current : itemRef.current);


### PR DESCRIPTION
Preventing scroll behavior only in certain cases like pressing arrow keys, so we can use other keys without problems.
Specific example: when using <input/> element inside MenuItem.

