### PR TITLE
feat(banners): mobile redesign for Grid and WithListImage sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanaco/lnc-react-ui",
-  "version": "4.0.239",
+  "version": "4.0.240",
   "description": "React component library",
   "type": "module",
   "keywords": [

--- a/src/Landing Sections/banners-sections/banner-section-grid/BannerSectionGrid.jsx
+++ b/src/Landing Sections/banners-sections/banner-section-grid/BannerSectionGrid.jsx
@@ -1,9 +1,27 @@
 /* eslint-disable react/display-name */
 /* eslint-disable react/prop-types */
 import { forwardRef } from "react";
-import { GridWrapper } from "./style";
+import { GridWrapper, MobileScrollWrapper } from "./style";
 import useDetectMobile from "../../../_utils/useDetectMobile";
 import TextBlockV1 from "../../../Landing Components/text-block-v1/index";
+
+const ArrowRight = () => (
+  <svg
+    className="banner-grid-card__arrow"
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <line x1="4" y1="12" x2="20" y2="12" />
+    <polyline points="13 5 20 12 13 19" />
+  </svg>
+);
 
 const BannerSectionGrid = forwardRef((props, ref) => {
   const {
@@ -25,8 +43,71 @@ const BannerSectionGrid = forwardRef((props, ref) => {
 
   const isMobile = useDetectMobile();
 
+  // Mobile: clickable image cards with title/button overlaid, horizontally
+  // scrollable (see design). Desktop layout below is left untouched.
+  if (isMobile === true) {
+    const cards = [
+      {
+        image: image1Url,
+        title: title1,
+        buttonText: buttonText1,
+        buttonLink: buttonLink1,
+      },
+      {
+        image: image2Url,
+        title: title2,
+        buttonText: buttonText2,
+        buttonLink: buttonLink2,
+      },
+    ];
+
+    return (
+      <MobileScrollWrapper
+        className="lp-section lp-bnr-section lp-banner-section-grid banner-section-grid-lnc banner-section-grid-mobile"
+        ref={ref}
+      >
+        {cards.map((card, index) => (
+          <a
+            key={index}
+            className="banner-grid-card"
+            role="button"
+            tabIndex={0}
+            onClick={() => onButtonAction(card.buttonLink)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onButtonAction(card.buttonLink);
+              }
+            }}
+          >
+            <img
+              className="banner-grid-card__img"
+              src={card.image}
+              alt={card.title || ""}
+            />
+            <div className="banner-grid-card__overlay">
+              {card.title && (
+                <div className="banner-grid-card__title">{card.title}</div>
+              )}
+              {card.buttonText && (
+                <div className="banner-grid-card__action">
+                  <span>{card.buttonText}</span>
+                  <ArrowRight />
+                </div>
+              )}
+            </div>
+          </a>
+        ))}
+      </MobileScrollWrapper>
+    );
+  }
+
   return (
-    <GridWrapper className="lp-section lp-bnr-section lp-banner-section-grid banner-section-grid-lnc" ref={ref} height={rowHeight}>
+    <GridWrapper
+      className="lp-section lp-bnr-section lp-banner-section-grid banner-section-grid-lnc"
+      ref={ref}
+      height={rowHeight}
+    >
       <TextBlockV1
         className="text-item"
         title={title1}
@@ -37,8 +118,7 @@ const BannerSectionGrid = forwardRef((props, ref) => {
         onButtonAction={onButtonAction}
       />
       <img className="img-item img-1" src={image1Url} />
-
-      {isMobile !== true && <img className="img-item img-2" src={image2Url} />}
+      <img className="img-item img-2" src={image2Url} />
       <TextBlockV1
         className="text-item"
         title={title2}
@@ -48,7 +128,6 @@ const BannerSectionGrid = forwardRef((props, ref) => {
         buttonLink={buttonLink2}
         onButtonAction={onButtonAction}
       />
-      {isMobile === true && <img className="img-item img-2" src={image2Url} />}
     </GridWrapper>
   );
 });

--- a/src/Landing Sections/banners-sections/banner-section-grid/style.jsx
+++ b/src/Landing Sections/banners-sections/banner-section-grid/style.jsx
@@ -1,6 +1,80 @@
 import styled from "@emotion/styled";
 import { down } from "../../../_utils/breakpoints";
 
+// Mobile-only: horizontally scrollable row of clickable image cards with the
+// title/button overlaid on the image (see design). Rendered only on mobile,
+// so no media query is needed here.
+export const MobileScrollWrapper = styled.div`
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 1rem;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  & .banner-grid-card {
+    position: relative;
+    flex: 0 0 auto;
+    width: 78%;
+    max-width: 22rem;
+    aspect-ratio: 4 / 3;
+    border-radius: 0.75rem;
+    overflow: hidden;
+    cursor: pointer;
+    text-decoration: none;
+    display: block;
+  }
+
+  & .banner-grid-card__img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  & .banner-grid-card__overlay {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    background: linear-gradient(
+      to top,
+      rgba(0, 0, 0, 0.75) 0%,
+      rgba(0, 0, 0, 0.35) 45%,
+      rgba(0, 0, 0, 0) 100%
+    );
+  }
+
+  & .banner-grid-card__title {
+    color: #fff;
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1.375rem;
+  }
+
+  & .banner-grid-card__action {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    color: #fff;
+    font-size: 0.875rem;
+    font-weight: 500;
+
+    & .banner-grid-card__arrow {
+      flex: 0 0 auto;
+    }
+  }
+`;
+
 export const GridWrapper = styled.div`
   display: grid;
   grid-template-columns: repeat(2, 1fr);

--- a/src/Landing Sections/banners-sections/banner-section-with-list-image/style.jsx
+++ b/src/Landing Sections/banners-sections/banner-section-with-list-image/style.jsx
@@ -27,10 +27,10 @@ export const Container = styled.div`
 `}
 
   @media ${down("S")} {
+    /* Keep the card (border / radius / shadow) on mobile so the text and
+       image read as one unified visual, with the image flush at the bottom
+       of the card (see design). */
     flex-direction: column;
-    border-radius: 0;
-    border: none;
-    box-shadow: none;
 
     & img {
       max-width: 100%;


### PR DESCRIPTION
BannerSectionGrid:
- On mobile, render the two banners as clickable image cards with the title and action overlaid on the image (gradient scrim), in a horizontally scrollable row with the next card peeking.
- Desktop layout and the component's props/API are unchanged; the new behaviour lives only in the mobile (isMobile) branch.

BannerSectionWithListImage:
- Keep the card border/radius/shadow on mobile so the text and image read as one unified visual with the image flush at the bottom of the card, instead of stripping the card styling.