### PR TITLE
feat(product-card): badges with text below image + always-visible action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanaco/lnc-react-ui",
-  "version": "4.0.240",
+  "version": "4.0.241",
   "description": "React component library",
   "type": "module",
   "keywords": [

--- a/src/Landing Components/product components/detailed-product-card/index.jsx
+++ b/src/Landing Components/product components/detailed-product-card/index.jsx
@@ -70,6 +70,7 @@ const DetailedProductCard = forwardRef((props, ref) => {
     onSelectCard = () => {},
     activeSalesPackages,
     urgentText = "Urgent",
+    freeShippingText = "",
     LinkComponent,
     hasFreeShipping,
   } = props;
@@ -323,6 +324,7 @@ const DetailedProductCard = forwardRef((props, ref) => {
           {shouldShowFreeShipping && (
             <div className="campaign-badge campaign-badge-freeshipping">
               <Icon icon={SalesPackageIcons?.FREESHIPPING} sizeInUnits="1rem" />
+              {freeShippingText && <span>{freeShippingText}</span>}
             </div>
           )}
 
@@ -342,7 +344,11 @@ const DetailedProductCard = forwardRef((props, ref) => {
                 />
               )}
 
-              {packageType?.salesPackageCode === "Urgent" && <>{urgentText}</>}
+              {packageType?.salesPackageCode === "Urgent" ? (
+                <>{urgentText}</>
+              ) : (
+                packageType?.label && <span>{packageType.label}</span>
+              )}
             </div>
           ))}
         </div>

--- a/src/Landing Components/product components/detailed-product-card/style.jsx
+++ b/src/Landing Components/product components/detailed-product-card/style.jsx
@@ -120,30 +120,33 @@ export const Wrapper = styled.a`
   }
 
   & .campaign-badges {
-    position: absolute;
-    top: 0.5rem;
-    left: 0.75rem;
+    /* Rendered below the image (above the title), ekupi-style, with text
+       labels next to the icons. */
     display: flex;
-    gap: 0.25rem;
+    gap: 0.375rem;
     flex-wrap: wrap;
+    align-items: center;
     justify-content: flex-start;
+    margin-top: 0.5rem;
     z-index: 1;
-    width: max-content;
-    max-width: 7rem;
   }
 
   & .campaign-badge {
     width: fit-content;
-    height: 1.5rem;
-    border-radius: 0.25rem;
+    min-height: 1.5rem;
+    border-radius: 0.5rem;
     display: flex;
     align-items: center;
-    justify-content: center;
+    gap: 0.25rem;
     color: white;
-    font-size: 1rem;
-    padding-inline: 0.15rem;
+    font-size: 0.75rem;
+    font-weight: 400;
+    line-height: 1;
+    padding-inline: 0.375rem;
 
     i {
+      font-size: 1rem;
+
       ::before {
         margin-inline: 0;
       }
@@ -164,6 +167,10 @@ export const Wrapper = styled.a`
 
   & .campaign-badge-includegifts {
     background-color: #8b5cf6;
+  }
+
+  & .campaign-badge-newcollection {
+    background-color: #f59e0b;
   }
 
   & .campaign-badge-urgent {
@@ -251,7 +258,9 @@ export const ImageWrapper = styled.div`
     top: 0.5rem;
     z-index: 1;
 
-    display: none;
+    /* Always visible (no longer hover-only on desktop) so the
+       add-to-cart / save action is discoverable at first glance. */
+    display: flex;
 
     align-items: center;
     justify-content: center;
@@ -272,12 +281,6 @@ export const ImageWrapper = styled.div`
       color: #14161a;
       font-size: 1.1rem;
       line-height: 1;
-    }
-  }
-
-  &:hover {
-    & .bookmarking-btn {
-      display: flex;
     }
   }
 

--- a/src/Landing Sections/products-sections/detailed-products-section/DetailedProductsSection.jsx
+++ b/src/Landing Sections/products-sections/detailed-products-section/DetailedProductsSection.jsx
@@ -44,6 +44,7 @@ const DetailedProductsSection = forwardRef((props, ref) => {
     componentName,
     LinkComponent,
     urgentText,
+    freeShippingText,
   } = props;
 
   const isMobile = useDetectMobile();
@@ -95,6 +96,7 @@ const DetailedProductsSection = forwardRef((props, ref) => {
                 LinkComponent={LinkComponent}
                 activeSalesPackages={x?.activeSalesPackages}
                 urgentText={urgentText}
+                freeShippingText={freeShippingText}
                 hasFreeShipping={x?.hasFreeShipping}
               />
             ))
@@ -142,6 +144,7 @@ const DetailedProductsSection = forwardRef((props, ref) => {
                 LinkComponent={LinkComponent}
                 activeSalesPackages={x?.activeSalesPackages}
                 urgentText={urgentText}
+                freeShippingText={freeShippingText}
                 hasFreeShipping={x?.hasFreeShipping}
               />
             ))}

--- a/src/Landing Sections/products-sections/detailed-products-section/detailed-products-section.stories.mdx
+++ b/src/Landing Sections/products-sections/detailed-products-section/detailed-products-section.stories.mdx
@@ -18,6 +18,13 @@ export const TemplateDefault = (args) => (
     limit={6}
     getImage={(x, y, z) => x}
     isLoading={false}
+    urgentText="Hitno"
+    freeShippingText="Besplatna dostava"
+    actionComponent={
+      <button className="bookmarking-btn" type="button" aria-label="Add to cart">
+        <i className="mng mng-lnc-cart-plus" />
+      </button>
+    }
     allOptionsEnabled={true}
     allOptionsLabel="Svi"
     options={[
@@ -42,6 +49,14 @@ export const TemplateDefault = (args) => (
         sponsored: true,
         location: "Banja Luka",
         categoryCode: "RealEstates_Apartments",
+        activeSalesPackages: [
+          {
+            salesPackageCode: "AddDiscount",
+            discountAmount: 15,
+            discountCode: "Percentage",
+            label: "-15%",
+          },
+        ],
         tags: [
           {
             code: "AdType",
@@ -74,6 +89,10 @@ export const TemplateDefault = (args) => (
         quantity: "1 na stanju",
         trade: "Zamjena",
         hasFreeShipping: true,
+        activeSalesPackages: [
+          { salesPackageCode: "IncludeGifts", label: "Pokloni" },
+          { salesPackageCode: "NewCollection", label: "Nova kolekcija" },
+        ],
       },
       {
         name: "Minimalist Stuiod | Urbal Core | Studio",
@@ -85,6 +104,10 @@ export const TemplateDefault = (args) => (
         uuid: "9e32f86d-9f21-4776-9b44-ea40d3403024",
         location: "Banja Luka",
         categoryCode: "Vehicles_Cars",
+        activeSalesPackages: [
+          { salesPackageCode: "FreeQuantity", label: "Kupi 2 dobij 1" },
+          { salesPackageCode: "Urgent" },
+        ],
         tags: [
           {
             code: "AdType",


### PR DESCRIPTION
detailed-product-card:
- Always show the add-to-cart / save button (was hover-only on desktop), so the action is discoverable at first glance.
- Move the sales-package badges from an overlay on the image to a row below the image (ekupi-style), rendering icon + text label per badge.
- Add optional `freeShippingText` prop and a `newcollection` badge color. Falls back to icon-only when no label is provided (backward compatible).

DetailedProductsSection:
- Forward `freeShippingText` to the card.