### PR TITLE
revert(product-card): drop badge text labels, keep always-visible action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanaco/lnc-react-ui",
-  "version": "4.0.241",
+  "version": "4.0.242",
   "description": "React component library",
   "type": "module",
   "keywords": [

--- a/src/Landing Components/product components/detailed-product-card/index.jsx
+++ b/src/Landing Components/product components/detailed-product-card/index.jsx
@@ -70,7 +70,6 @@ const DetailedProductCard = forwardRef((props, ref) => {
     onSelectCard = () => {},
     activeSalesPackages,
     urgentText = "Urgent",
-    freeShippingText = "",
     LinkComponent,
     hasFreeShipping,
   } = props;
@@ -324,7 +323,6 @@ const DetailedProductCard = forwardRef((props, ref) => {
           {shouldShowFreeShipping && (
             <div className="campaign-badge campaign-badge-freeshipping">
               <Icon icon={SalesPackageIcons?.FREESHIPPING} sizeInUnits="1rem" />
-              {freeShippingText && <span>{freeShippingText}</span>}
             </div>
           )}
 
@@ -344,11 +342,7 @@ const DetailedProductCard = forwardRef((props, ref) => {
                 />
               )}
 
-              {packageType?.salesPackageCode === "Urgent" ? (
-                <>{urgentText}</>
-              ) : (
-                packageType?.label && <span>{packageType.label}</span>
-              )}
+              {packageType?.salesPackageCode === "Urgent" && <>{urgentText}</>}
             </div>
           ))}
         </div>

--- a/src/Landing Components/product components/detailed-product-card/style.jsx
+++ b/src/Landing Components/product components/detailed-product-card/style.jsx
@@ -120,33 +120,30 @@ export const Wrapper = styled.a`
   }
 
   & .campaign-badges {
-    /* Rendered below the image (above the title), ekupi-style, with text
-       labels next to the icons. */
+    position: absolute;
+    top: 0.5rem;
+    left: 0.75rem;
     display: flex;
-    gap: 0.375rem;
+    gap: 0.25rem;
     flex-wrap: wrap;
-    align-items: center;
     justify-content: flex-start;
-    margin-top: 0.5rem;
     z-index: 1;
+    width: max-content;
+    max-width: 7rem;
   }
 
   & .campaign-badge {
     width: fit-content;
-    min-height: 1.5rem;
-    border-radius: 0.5rem;
+    height: 1.5rem;
+    border-radius: 0.25rem;
     display: flex;
     align-items: center;
-    gap: 0.25rem;
+    justify-content: center;
     color: white;
-    font-size: 0.75rem;
-    font-weight: 400;
-    line-height: 1;
-    padding-inline: 0.375rem;
+    font-size: 1rem;
+    padding-inline: 0.15rem;
 
     i {
-      font-size: 1rem;
-
       ::before {
         margin-inline: 0;
       }
@@ -167,10 +164,6 @@ export const Wrapper = styled.a`
 
   & .campaign-badge-includegifts {
     background-color: #8b5cf6;
-  }
-
-  & .campaign-badge-newcollection {
-    background-color: #f59e0b;
   }
 
   & .campaign-badge-urgent {
@@ -275,6 +268,7 @@ export const ImageWrapper = styled.div`
 
     &:hover {
       transform: scale(1.05);
+      background-color: white;
     }
 
     i {

--- a/src/Landing Sections/products-sections/detailed-products-section/DetailedProductsSection.jsx
+++ b/src/Landing Sections/products-sections/detailed-products-section/DetailedProductsSection.jsx
@@ -44,7 +44,6 @@ const DetailedProductsSection = forwardRef((props, ref) => {
     componentName,
     LinkComponent,
     urgentText,
-    freeShippingText,
   } = props;
 
   const isMobile = useDetectMobile();
@@ -96,7 +95,6 @@ const DetailedProductsSection = forwardRef((props, ref) => {
                 LinkComponent={LinkComponent}
                 activeSalesPackages={x?.activeSalesPackages}
                 urgentText={urgentText}
-                freeShippingText={freeShippingText}
                 hasFreeShipping={x?.hasFreeShipping}
               />
             ))
@@ -144,7 +142,6 @@ const DetailedProductsSection = forwardRef((props, ref) => {
                 LinkComponent={LinkComponent}
                 activeSalesPackages={x?.activeSalesPackages}
                 urgentText={urgentText}
-                freeShippingText={freeShippingText}
                 hasFreeShipping={x?.hasFreeShipping}
               />
             ))}

--- a/src/Landing Sections/products-sections/detailed-products-section/detailed-products-section.stories.mdx
+++ b/src/Landing Sections/products-sections/detailed-products-section/detailed-products-section.stories.mdx
@@ -18,8 +18,6 @@ export const TemplateDefault = (args) => (
     limit={6}
     getImage={(x, y, z) => x}
     isLoading={false}
-    urgentText="Hitno"
-    freeShippingText="Besplatna dostava"
     actionComponent={
       <button className="bookmarking-btn" type="button" aria-label="Add to cart">
         <i className="mng mng-lnc-cart-plus" />
@@ -49,14 +47,6 @@ export const TemplateDefault = (args) => (
         sponsored: true,
         location: "Banja Luka",
         categoryCode: "RealEstates_Apartments",
-        activeSalesPackages: [
-          {
-            salesPackageCode: "AddDiscount",
-            discountAmount: 15,
-            discountCode: "Percentage",
-            label: "-15%",
-          },
-        ],
         tags: [
           {
             code: "AdType",
@@ -89,10 +79,6 @@ export const TemplateDefault = (args) => (
         quantity: "1 na stanju",
         trade: "Zamjena",
         hasFreeShipping: true,
-        activeSalesPackages: [
-          { salesPackageCode: "IncludeGifts", label: "Pokloni" },
-          { salesPackageCode: "NewCollection", label: "Nova kolekcija" },
-        ],
       },
       {
         name: "Minimalist Stuiod | Urbal Core | Studio",
@@ -104,10 +90,6 @@ export const TemplateDefault = (args) => (
         uuid: "9e32f86d-9f21-4776-9b44-ea40d3403024",
         location: "Banja Luka",
         categoryCode: "Vehicles_Cars",
-        activeSalesPackages: [
-          { salesPackageCode: "FreeQuantity", label: "Kupi 2 dobij 1" },
-          { salesPackageCode: "Urgent" },
-        ],
         tags: [
           {
             code: "AdType",


### PR DESCRIPTION
- Revert the below-image badge redesign (#10): badges are icon-only again and positioned over the image as before. Removes the text labels, the freeShippingText prop/forwarding and the newcollection color.

- Keep the add-to-cart / save button is always visible (no longer hover-only on desktop) and keeps a white background on hover so the button's own hover color doesn't bleed over the image.
